### PR TITLE
Add authentication methods and email platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,16 @@ await gk.apikeys.list();
 
 ## Auth
 
-### Get current authentication context and permissions
+### Create a new user account (first user becomes admin)
 ```typescript
-// Usage example
-await gk.auth.whoami();
+// Create first admin user
+await gk.auth.signup(data);
+```
+
+### Login with email and password
+```typescript
+// Login with email and password
+await gk.auth.login(data);
 ```
 
 ## Identities

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatekit/sdk",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Official TypeScript SDK for GateKit universal messaging gateway",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,6 +8,7 @@ import {
   ApiKeyListResponse,
   ApiKeyResponse,
   ApiKeyRollResponse,
+  AuthResponse,
   CreateApiKeyDto,
   CreateIdentityDto,
   CreatePlatformDto,
@@ -16,6 +17,7 @@ import {
   GateKitConfig,
   IdentityAliasResponse,
   IdentityResponse,
+  LoginDto,
   MessageListResponse,
   MessageResponse,
   MessageRetryResponse,
@@ -34,6 +36,7 @@ import {
   SendMessageDto,
   SendReactionDto,
   SentMessageResponse,
+  SignupDto,
   SupportedPlatformsResponse,
   UpdateIdentityDto,
   UpdateMemberRoleDto,
@@ -73,6 +76,18 @@ class ApikeysAPI {
 
 class AuthAPI {
   constructor(private client: AxiosInstance, private gatekit: GateKit) {}
+
+  async signup(options: SignupDto): Promise<AuthResponse> {
+    const data = options;
+    const response = await this.client.post<AuthResponse>(`/api/v1/auth/signup`, data);
+    return response.data;
+  }
+
+  async login(options: LoginDto): Promise<AuthResponse> {
+    const data = options;
+    const response = await this.client.post<AuthResponse>(`/api/v1/auth/login`, data);
+    return response.data;
+  }
 
   async whoami(): Promise<PermissionResponse> {
     const response = await this.client.get<PermissionResponse>(`/api/v1/auth/whoami`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ export * from './types';
 export * from './errors';
 
 // Version info
-export const SDK_VERSION = '1.2.1';
-export const GENERATED_AT = '2025-10-02T22:42:11.028Z';
-export const CONTRACTS_COUNT = 51;
+export const SDK_VERSION = '1.3.0';
+export const GENERATED_AT = '2025-10-04T15:18:18.308Z';
+export const CONTRACTS_COUNT = 53;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,16 @@ export interface AttachmentDto {
   caption?: string;
 }
 
+export interface AuthResponse {
+  accessToken: string;
+  user: {
+    id: string;
+    email: string;
+    name?: string;
+    isAdmin: boolean;
+  };
+}
+
 export interface ButtonDto {
   text: string;
   value?: string;
@@ -61,10 +71,14 @@ export interface ButtonDto {
 export type ButtonStyle = 'primary' | 'secondary' | 'success' | 'danger' | 'link';
 
 export interface ContentDto {
+  subject?: string;
   text?: string;
+  markdown?: string;
+  html?: string;
   attachments?: AttachmentDto[];
   buttons?: ButtonDto[];
   embeds?: EmbedDto[];
+  platformOptions?: Record<string, any>;
 }
 
 export interface CreateApiKeyDto {
@@ -162,6 +176,11 @@ export interface IdentityResponse {
   createdAt: Date;
   updatedAt: Date;
   aliases: IdentityAliasResponse[];
+}
+
+export interface LoginDto {
+  email: string;
+  password: string;
 }
 
 export interface MessageListResponse {
@@ -310,7 +329,7 @@ export interface PlatformResponse {
   updatedAt: Date;
 }
 
-export type PlatformType = 'discord' | 'telegram' | 'whatsapp-evo';
+export type PlatformType = 'discord' | 'telegram' | 'whatsapp-evo' | 'email';
 
 export type Priority = 'low' | 'normal' | 'high';
 
@@ -423,6 +442,12 @@ export interface SentMessageResponse {
   createdAt: Date;
 }
 
+export interface SignupDto {
+  email: string;
+  password: string;
+  name?: string;
+}
+
 export interface SupportedPlatformsResponse {
   platforms: Array<{
     name: string;
@@ -528,6 +553,29 @@ export interface WebhookResponse {
   createdAt: Date;
   updatedAt: Date;
   message?: string;
+}
+
+/**
+ * Platform-specific options for Email (SMTP)
+ * Auto-generated from EmailPlatformOptions
+ */
+export interface EmailPlatformOptions {
+  /** CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email */
+  cc?: string[];
+  /** BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing */
+  bcc?: string[];
+  /** Reply-To address Email address where replies should be sent (different from sender) */
+  replyTo?: string;
+  /** Custom SMTP headers Advanced: Add custom headers to the email */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Platform-specific options for all supported platforms
+ * Use this in platformOptions field when sending messages
+ */
+export interface PlatformOptions {
+  email?: EmailPlatformOptions;
 }
 
 // SDK configuration


### PR DESCRIPTION
## Summary

Adds authentication methods (signup/login) and email platform support to the SDK. This update includes new content fields and platform-specific options for enhanced messaging capabilities.

**Version**: v  
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### New Features

- **Authentication Methods**: Added  and  methods to 
- **Email Platform Support**: Added  to supported platform types
- **Enhanced Content Fields**: Added , , , and  to 
- **Email Platform Options**: New  interface with CC, BCC, replyTo, and custom headers support

### Type Changes

- Added , , and  interfaces
- Added  and  interfaces for platform-specific messaging options
- Updated  to include 
- Enhanced  with universal message fields

### Contract Updates

- Increased from 51 to 53 contracts
- Generated at: 
