### PR TITLE
Add dynamic token support for browser applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatekit/sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Official TypeScript SDK for GateKit universal messaging gateway",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -407,7 +407,18 @@ export class GateKit {
   }
 
   private setupAuthentication(config: GateKitConfig): void {
-    if (config.apiKey) {
+    // For dynamic tokens (browser apps) - use interceptor
+    if (config.getToken) {
+      this.client.interceptors.request.use((axiosConfig) => {
+        const token = config.getToken!();
+        if (token) {
+          axiosConfig.headers.Authorization = `Bearer ${token}`;
+        }
+        return axiosConfig;
+      });
+    }
+    // For static credentials (CLI, server-side) - use defaults (faster)
+    else if (config.apiKey) {
       this.client.defaults.headers['X-API-Key'] = config.apiKey;
     } else if (config.jwtToken) {
       this.client.defaults.headers['Authorization'] = `Bearer ${config.jwtToken}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ export * from './types';
 export * from './errors';
 
 // Version info
-export const SDK_VERSION = '1.3.0';
-export const GENERATED_AT = '2025-10-04T15:18:18.308Z';
+export const SDK_VERSION = '1.4.0';
+export const GENERATED_AT = '2025-10-05T02:14:05.364Z';
 export const CONTRACTS_COUNT = 53;

--- a/src/types.ts
+++ b/src/types.ts
@@ -583,6 +583,7 @@ export interface GateKitConfig {
   apiUrl: string;
   apiKey?: string;
   jwtToken?: string;
+  getToken?: () => string | null; // Dynamic token getter (preferred over jwtToken)
   defaultProject?: string;
   timeout?: number;
   retries?: number;


### PR DESCRIPTION
## Summary

Added dynamic token support for browser applications through a new  function in the SDK configuration, enabling real-time token refresh for client-side applications.

**Version**: v
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

- **New  configuration option**: Added optional  to  interface
- **Dynamic authentication**: SDK now supports runtime token resolution through request interceptor
- **Browser app support**: Enables token refresh flows for client-side applications where tokens may expire
- **Performance optimization**: Static credentials (API keys, JWT tokens) still use faster defaults approach
- **Version bump**: Updated from v1.3.0 to v1.4.0

### Implementation Details

The SDK now supports two authentication modes:

1. **Dynamic tokens** (new): Uses Axios request interceptor to call  on each request
2. **Static credentials** (existing): Uses Axios defaults for API keys and JWT tokens (faster)

This change enables browser applications to implement token refresh logic while maintaining backward compatibility and performance for server-side usage.
