### PR TITLE
Add dynamic token authentication support for browser applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatekit/sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official TypeScript SDK for GateKit universal messaging gateway",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -407,7 +407,18 @@ export class GateKit {
   }
 
   private setupAuthentication(config: GateKitConfig): void {
-    if (config.apiKey) {
+    // For dynamic tokens (browser apps) - use interceptor
+    if (config.getToken) {
+      this.client.interceptors.request.use((axiosConfig) => {
+        const token = config.getToken!();
+        if (token) {
+          axiosConfig.headers.Authorization = `Bearer ${token}`;
+        }
+        return axiosConfig;
+      });
+    }
+    // For static credentials (CLI, server-side) - use defaults (faster)
+    else if (config.apiKey) {
       this.client.defaults.headers['X-API-Key'] = config.apiKey;
     } else if (config.jwtToken) {
       this.client.defaults.headers['Authorization'] = `Bearer ${config.jwtToken}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ export * from './types';
 export * from './errors';
 
 // Version info
-export const SDK_VERSION = '1.3.0';
-export const GENERATED_AT = '2025-10-04T15:18:18.308Z';
+export const SDK_VERSION = '1.3.1';
+export const GENERATED_AT = '2025-10-05T02:47:11.887Z';
 export const CONTRACTS_COUNT = 53;

--- a/src/types.ts
+++ b/src/types.ts
@@ -583,6 +583,7 @@ export interface GateKitConfig {
   apiUrl: string;
   apiKey?: string;
   jwtToken?: string;
+  getToken?: () => string | null; // Dynamic token getter (preferred over jwtToken)
   defaultProject?: string;
   timeout?: number;
   retries?: number;


### PR DESCRIPTION
## Summary

Adds dynamic token authentication support via  callback function, enabling browser applications to refresh JWT tokens automatically.

**Version**: v1.3.1
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

- **New authentication method**: Added  to 
- **Dynamic token support**: SDK now supports runtime token refresh for browser apps
- **Optimized authentication**: Static credentials use defaults (faster), dynamic tokens use interceptors
- **Version bump**: Updated from 1.3.0 → 1.3.1

### Authentication Options

The SDK now supports three authentication patterns:



This enables browser applications to handle token expiration gracefully without manual client reconfiguration.
